### PR TITLE
Fix colors.cpp compilation

### DIFF
--- a/colors.cpp
+++ b/colors.cpp
@@ -1,6 +1,7 @@
 #include "colors.h"
 #include "matrix.h"
 //
+#include <cstdio>
 #include <cmath>
 #include <iostream>
 


### PR DESCRIPTION
colors.cpp:106:43: error: ‘sprintf’ was not declared in this scope
     sprintf(out_path, "%s_lrs", out_prefix);